### PR TITLE
Fix rest stop bug

### DIFF
--- a/pkg/framework/kubescheduler.go
+++ b/pkg/framework/kubescheduler.go
@@ -400,7 +400,10 @@ func (s *kubeschedulerFramework) Run() error {
 	if s.dynInformerFactory != nil {
 		s.dynInformerFactory.WaitForCacheSync(s.informerCh)
 	}
-	go s.scheduler.Run(context.TODO())
+
+	ctx, cancel := context.WithCancel(context.TODO())
+	defer cancel()
+	go s.scheduler.Run(ctx)
 
 	<-s.stopCh
 


### PR DESCRIPTION

#### What type of PR is this?
/kind bug


#### What this PR does / why we need it:
1. resolve scheduler not exit when call kubescheduler Stop
2. resolve restmapper getAPIGroupResourcesres error when restConfig is nil

#### Which issue(s) this PR fixes:
<!--
*Automatically closes linked issue when PR is merged.
Usage: `Fixes #<issue number>`, or `Fixes (paste link of issue)`.
_If PR is about `failing-tests or flakes`, please post the related issues/tests in a comment and do not use `Fixes`_*
-->
Fixes #

#### Special notes for your reviewer:
none
#### Does this PR introduce a user-facing change?
<!--
If no, just write "NONE" in the release-note block below.
If yes, a release note is required:
Enter your extended release note in the block below. If the PR requires additional action from users switching to the new release, include the string "action required".

For more information on release notes see: https://git.k8s.io/community/contributors/guide/release-notes.md
-->
```release-note
none
```

#### Additional documentation e.g., KEPs (Kubernetes Enhancement Proposals), usage docs, etc.:

<!--
This section can be blank if this pull request does not require a release note.

When adding links which point to resources within git repositories, like
KEPs or supporting documentation, please reference a specific commit and avoid
linking directly to the master branch. This ensures that links reference a
specific point in time, rather than a document that may change over time.

See here for guidance on getting permanent links to files: https://help.github.com/en/articles/getting-permanent-links-to-files

Please use the following format for linking documentation:
- [KEP]: <link>
- [Usage]: <link>
- [Other doc]: <link>
-->
```docs
none
```
